### PR TITLE
Fixed quotation

### DIFF
--- a/svgo.applescript
+++ b/svgo.applescript
@@ -3,10 +3,10 @@ on adding folder items to this_folder after receiving these_items
     repeat with i from 1 to number of items in these_items
 
         set this_item to item i of these_items
-        set the file_path to the quoted form of the POSIX path of this_item
+        set the file_path to the POSIX path of this_item
 
         try
-            do shell script "/bin/bash -l -c 'svgo " & file_path & "'"
+            do shell script "/bin/bash -l -c 'svgo \"" & file_path & "\"'"
         on error errStr number errorNumber
             display dialog "Error: " & errStr buttons {"OK"} with icon stop
             return number


### PR DESCRIPTION
The folder action doesn't work for me on files with POSIX paths that contain a space or a special character like an Emoji.

The svgo command is read from string (-c) and already is inside single quotation marks, therefore the quoted form of the POSIX path in it has to be inside double quotation marks. With this changes the Script works for me.
